### PR TITLE
Normalize chart points for 1w and 2w data.

### DIFF
--- a/XRatesKit/Classes/ObjectMappers/CoinGecko/CoinGeckoMarketChartsMapper.swift
+++ b/XRatesKit/Classes/ObjectMappers/CoinGecko/CoinGeckoMarketChartsMapper.swift
@@ -1,6 +1,49 @@
 import HsToolKit
 
 class CoinGeckoMarketChartsMapper: IApiMapper {
+    private let intervalInSeconds: TimeInterval?
+
+    init(intervalInSeconds: TimeInterval? = nil) {
+        self.intervalInSeconds = intervalInSeconds
+    }
+
+    private func nearest(timestamp: TimeInterval, truncInterval: TimeInterval) -> TimeInterval {
+        let lower = floor(timestamp / truncInterval) * truncInterval
+        return (timestamp - lower > truncInterval / 2) ? (lower + truncInterval) : lower
+    }
+
+    private func normalize(charts: [ChartPoint]) -> [ChartPoint] {
+        guard let intervalInSeconds = intervalInSeconds else {
+            return charts
+        }
+
+        var normalized = [TimeInterval: ChartPoint]()
+        var latestDelta: TimeInterval = 0
+
+        let normalizedInterval: TimeInterval
+        let hourInterval: TimeInterval = 60 * 60
+        let dayInterval = 24 * hourInterval
+
+        switch intervalInSeconds {
+        case 0 ..< hourInterval: normalizedInterval = 60                           // normalize to nearest minute if interval less than day
+        case hourInterval ..< dayInterval: normalizedInterval = hourInterval       // normalize to nearest hour if interval from day to
+        default: normalizedInterval = dayInterval                                  // normalize to nearest day if other interval
+        }
+
+        for point in charts {
+            let normalizedInterval = nearest(timestamp: point.timestamp, truncInterval: normalizedInterval)
+            let delta = abs(normalizedInterval - point.timestamp)
+
+            if normalized[normalizedInterval] != nil, delta > latestDelta {
+                continue
+            }
+
+            normalized[normalizedInterval] = point
+            latestDelta = delta
+        }
+
+        return normalized.sorted(by: { $0.0 < $1.0 }).map { key, point in ChartPoint(timestamp: key, value: point.value, volume: point.volume)}
+    }
 
     func map(statusCode: Int, data: Any?) throws -> [ChartPoint] {
         var charts = [ChartPoint]()
@@ -20,7 +63,7 @@ class CoinGeckoMarketChartsMapper: IApiMapper {
             }
         }
 
-        return charts
+        return normalize(charts: charts)
     }
 
 }


### PR DESCRIPTION
Change timestamps to nearest interval. 4h/8h points move to candle closed-values.